### PR TITLE
Add fastify as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,9 @@
     "express": "^4.17.1",
     "fastify-plugin": "^2.0.0"
   },
+  "peerDependencies": {
+    "fastify": "^3.0.0"
+  },
   "engines": {
     "node": ">=10.0.0"
   }


### PR DESCRIPTION
This PR adds fastify as a peer dependency so that it works with Yarn v2 without having to override the package.
```
Error: fastify-express tried to access fastify, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.
```
Yarn v2 enforces packages to list all dependencies that are used by that package. In this case, fastify is provided by the user so it should be a peer dependency.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
