### PR TITLE
fix: decorate missing protocol field

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,12 +42,16 @@ function expressPlugin (fastify, options, next) {
     req.raw.ips = req.ips
     req.raw.log = req.log
     reply.raw.log = req.log
-    // added in Fastify@3.5. Make it lazy as it does a bit of work
+
+    const originalProtocol = req.raw.protocol
+    // Make it lazy as it does a bit of work
     Object.defineProperty(req.raw, 'protocol', {
       get () {
-        return req.protocol
+        // added in Fastify@3.5, so handle it missing
+        return req.protocol || originalProtocol
       }
     })
+
     next()
   }
 

--- a/index.js
+++ b/index.js
@@ -42,10 +42,12 @@ function expressPlugin (fastify, options, next) {
     req.raw.ips = req.ips
     req.raw.log = req.log
     reply.raw.log = req.log
-    // added in Fastify@3.5
-    if (req.protocol) {
-      req.raw.protocol = req.protocol
-    }
+    // added in Fastify@3.5. Make it lazy as it does a bit of work
+    Object.defineProperty(req.raw, 'protocol', {
+      get () {
+        return req.protocol
+      }
+    })
     next()
   }
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,10 @@ function expressPlugin (fastify, options, next) {
     req.raw.ips = req.ips
     req.raw.log = req.log
     reply.raw.log = req.log
+    // added in Fastify@3.5
+    if (req.protocol) {
+      req.raw.protocol = req.protocol
+    }
     next()
   }
 

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -44,7 +44,11 @@ test('trust proxy protocol', (t) => {
 
   fastify.register(expressPlugin).after(() => {
     fastify.use('/', function (req, res) {
-      res.json({ ip: req.ip, hostname: req.hostname, protocol: req.protocol })
+      t.strictEqual(req.ip, '1.1.1.1', 'gets ip from x-forwarded-for')
+      t.strictEqual(req.hostname, 'example.com', 'gets hostname from x-forwarded-host')
+      t.strictEqual(req.protocol, 'lorem', 'gets protocol from x-forwarded-proto')
+
+      res.sendStatus(200)
     })
   })
 
@@ -60,12 +64,6 @@ test('trust proxy protocol', (t) => {
       url: address
     }, (err, res, data) => {
       t.error(err)
-
-      const parsed = JSON.parse(data)
-
-      t.strictEqual(parsed.ip, '1.1.1.1', 'gets ip from x-forwarded-for')
-      t.strictEqual(parsed.hostname, 'example.com', 'gets hostname from x-forwarded-host')
-      t.strictEqual(parsed.protocol, 'lorem', 'gets protocol from x-forwarded-proto')
     })
   })
 })

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -48,7 +48,7 @@ test('trust proxy protocol', (t) => {
     })
   })
 
-  fastify.listen(0, (err) => {
+  fastify.listen(0, (err, address) => {
     t.error(err)
     sget({
       method: 'GET',
@@ -57,7 +57,7 @@ test('trust proxy protocol', (t) => {
         'X-Forwarded-Host': 'example.com',
         'X-Forwarded-Proto': 'lorem'
       },
-      url: 'http://localhost:' + fastify.server.address().port
+      url: address
     }, (err, res, data) => {
       t.error(err)
 

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -7,7 +7,7 @@ const sget = require('simple-get').concat
 const expressPlugin = require('../index')
 
 test('Should enhance the Node.js core request/response objects', t => {
-  t.plan(9)
+  t.plan(10)
   const fastify = Fastify()
   t.teardown(fastify.close)
 
@@ -17,6 +17,7 @@ test('Should enhance the Node.js core request/response objects', t => {
     t.strictEqual(req.raw.originalUrl, req.raw.url)
     t.strictEqual(req.raw.id, req.id)
     t.strictEqual(req.raw.hostname, req.hostname)
+    t.strictEqual(req.raw.protocol, req.protocol)
     t.strictEqual(req.raw.ip, req.ip)
     t.deepEqual(req.raw.ips, req.ips)
     t.ok(req.raw.log)
@@ -31,6 +32,40 @@ test('Should enhance the Node.js core request/response objects', t => {
       url: address
     }, (err, res, data) => {
       t.error(err)
+    })
+  })
+})
+
+test('trust proxy protocol', (t) => {
+  t.plan(5)
+  const fastify = Fastify({ trustProxy: true })
+
+  t.tearDown(fastify.close.bind(fastify))
+
+  fastify.register(expressPlugin).after(() => {
+    fastify.use('/', function (req, res) {
+      res.json({ ip: req.ip, hostname: req.hostname, protocol: req.protocol })
+    })
+  })
+
+  fastify.listen(0, (err) => {
+    t.error(err)
+    sget({
+      method: 'GET',
+      headers: {
+        'X-Forwarded-For': '1.1.1.1',
+        'X-Forwarded-Host': 'example.com',
+        'X-Forwarded-Proto': 'lorem'
+      },
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, res, data) => {
+      t.error(err)
+
+      const parsed = JSON.parse(data)
+
+      t.strictEqual(parsed.ip, '1.1.1.1', 'gets ip from x-forwarded-for')
+      t.strictEqual(parsed.hostname, 'example.com', 'gets hostname from x-forwarded-host')
+      t.strictEqual(parsed.protocol, 'lorem', 'gets protocol from x-forwarded-proto')
     })
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)

Noticed when deploying our app that `req.protocol` in our express middleware didn't seem to respect `trustProxy`. After going down a rabbit hole adding `express.enable('trust proxy')` I came over https://github.com/fastify/fastify/pull/2582 which seems to be the correct solution. Added a test based on that PR as well that fails if changes in this PR is rolled back or `trustProxy: false`.