### PR TITLE
Remove named export from TypeScript declarations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,6 @@ declare module 'fastify' {
   }
 }
 
-export const fastifyExpress: FastifyPluginCallback
+declare const fastifyExpress: FastifyPluginCallback
 
 export default fastifyExpress


### PR DESCRIPTION
Fixes #90.

Removes the named export `fastifyExpress` which does not exist at runtime.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
