### PR TITLE
feat: Make `prefix` come directly from fastify

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const fp = require('fastify-plugin')
-const symbols = require('fastify/lib/symbols')
 const Express = require('express')
 const kMiddlewares = Symbol('fastify-express-middlewares')
 
@@ -22,7 +21,7 @@ function expressPlugin (fastify, options, next) {
 
   function use (path, fn) {
     if (typeof path === 'string') {
-      const prefix = this[symbols.kRoutePrefix]
+      const prefix = this.prefix
       path = prefix + (path === '/' && prefix.length > 0 ? '' : path)
     }
     this[kMiddlewares].push([path, fn])

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
     "express": "^4.17.1",
     "fastify-plugin": "^4.0.0"
   },
+  "peerDependencies": {
+    "fastify": "^4"
+  },
   "tsd": {
     "directory": "test/types"
   },

--- a/package.json
+++ b/package.json
@@ -44,9 +44,6 @@
     "express": "^4.17.1",
     "fastify-plugin": "^4.0.0"
   },
-  "peerDependencies": {
-    "fastify": "^4"
-  },
   "tsd": {
     "directory": "test/types"
   },


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)


`@fastify/express` is requiring `fastify` in the following line. 

https://github.com/fastify/fastify-express/blob/0e960f8ad3ea9be55c5c66091ba6ffcd97caae2e/index.js#L4

However, it does not specify `fastify` in neither `dependencies` nor `peerDependencies`, making the app break in stricter runtimes such as [Yarn PnP](https://yarnpkg.com/features/pnp). (See [packages should only ever require what they formally list in their dependencies](https://yarnpkg.com/advanced/rulebook#packages-should-only-ever-require-what-they-formally-list-in-their-dependencies))
```
Error: @fastify/express tried to access fastify, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: fastify (via "fastify/lib/symbols")
Required by: @fastify/express@npm:2.0.2 (via /.../node_modules/@fastify/express/)
```

I have fixed this behavior by adding `fastify` to `peerDependencies` in the package manifest.