### PR TITLE
Add support for wrapping Express req with Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,27 @@ async function subsystem (fastify, opts) {
 }
 ```
 
+### Wrap Express req in Proxy
+
+It is possible to wrap the Express request object in a Proxy by passing `createProxyHandler` function to generate the Proxy handler. The function will receive the Fastify request object as the first parameter.
+
+For example using Proxy to expose something from Fastify request into the Express request.
+
+```js
+fastify.decorateRequest('welcomeMessage', 'Hello World');
+fastify.register(expressPlugin, {
+  createProxyHandler: fastifyRequest => ({
+    get (target, prop) {
+      if (prop === 'welcomeMessage') {
+        return fastifyRequest[prop]
+      }
+
+      return target[prop]
+    }
+  })
+})
+```
+
 ## TypeScript support
 
 To use this module with TypeScript, make sure to install `@types/express`.

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ const kMiddlewares = Symbol('fastify-express-middlewares')
 
 function fastifyExpress (fastify, options, next) {
   const {
-    expressHook = 'onRequest'
+    expressHook = 'onRequest',
+    createProxyHandler
   } = options
 
   fastify.decorate('use', use)
@@ -34,6 +35,11 @@ function fastifyExpress (fastify, options, next) {
   }
 
   function enhanceRequest (req, reply, next) {
+    // Allow attaching custom Proxy handlers to Express req
+    if (typeof createProxyHandler === 'function') {
+      req.raw = new Proxy(req.raw, createProxyHandler(req))
+    }
+
     req.raw.originalUrl = req.raw.url
     req.raw.id = req.id
     req.raw.hostname = req.hostname

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -67,3 +67,121 @@ test('trust proxy protocol', (t) => {
     })
   })
 })
+
+test('passing createProxyHandler sets up a Proxy with Express req', t => {
+  t.plan(8)
+  const testString = 'test proxy'
+
+  const fastify = Fastify()
+  fastify.register(expressPlugin, {
+    createProxyHandler: () => ({
+      set (target, prop, value) {
+        if (prop === 'customField') {
+          t.equal(value, testString)
+        }
+
+        return Reflect.set(target, prop, value)
+      },
+      get (target, prop) {
+        if (prop === 'customField') {
+          t.pass('get customField called')
+        }
+
+        return target[prop]
+      }
+    })
+  })
+    .after(() => {
+      fastify.use(function (req, res, next) {
+        req.customField = testString
+        t.equal(req.customField, testString)
+        next()
+      })
+    })
+
+  fastify.get('/', function (request, reply) {
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    t.teardown(fastify.server.close.bind(fastify.server))
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})
+
+test('createProxyHandler has access to Fastify request object', t => {
+  t.plan(12)
+  const startTestString = 'original'
+
+  const fastify = Fastify()
+  fastify.decorateRequest('getAndSetFastify', startTestString)
+  fastify.decorateRequest('getOnlyFastify', startTestString)
+
+  fastify.register(expressPlugin, {
+    createProxyHandler: fastifyReq => ({
+      set (target, prop, value) {
+        if (prop === 'getAndSetFastify') {
+          t.pass('set to Fastify called')
+          return Reflect.set(fastifyReq, prop, value)
+        } else if (prop === 'getOnlyFastify') {
+          return true
+        } else {
+          return Reflect.set(target, prop, value)
+        }
+      },
+      get (target, prop) {
+        if (prop === 'getAndSetFastify' || prop === 'getOnlyFastify') {
+          // Return something from Fastify req
+          t.pass('get from Fastify called')
+          return fastifyReq[prop]
+        }
+
+        return target[prop]
+      }
+    })
+  })
+    .after(() => {
+      fastify.use(function (req, res, next) {
+        t.equal(req.getAndSetFastify, startTestString)
+        t.equal(req.getOnlyFastify, startTestString)
+        req.getAndSetFastify = 'updated'
+        req.getOnlyFastify = 'updated'
+        next()
+      })
+    })
+
+  fastify.get('/', function (request, reply) {
+    // getOnlyFastify should change and getOnlyFastify should not
+    t.equal(request.getAndSetFastify, 'updated')
+    t.equal(request.getOnlyFastify, startTestString)
+
+    reply.send({ hello: 'world' })
+  })
+
+  fastify.listen({ port: 0 }, err => {
+    t.error(err)
+
+    t.teardown(fastify.server.close.bind(fastify.server))
+
+    sget({
+      method: 'GET',
+      url: 'http://localhost:' + fastify.server.address().port
+    }, (err, response, body) => {
+      t.error(err)
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers['content-length'], '' + body.length)
+      t.same(JSON.parse(body), { hello: 'world' })
+    })
+  })
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
-import { Application } from 'express'
-import { FastifyPluginCallback } from 'fastify'
+import { Application, Request } from 'express'
+import { FastifyPluginCallback, FastifyRequest } from 'fastify'
 
 declare module 'fastify' {
   interface FastifyInstance {
@@ -21,6 +21,7 @@ declare namespace fastifyExpress {
   
   export interface FastifyExpressOptions {
     expressHook?: string;
+    createProxyHandler?: (fastifyReq: FastifyRequest) => ProxyHandler<Request>
   }
 
   export const fastifyExpress: FastifyExpress

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -5,7 +5,6 @@ import { Application } from 'express'
 
 const app = Fastify()
 
-app.decorateRequest('testTsd', '')
 app.register(fastifyExpress)
 app.register(fastifyExpress, {
   expressHook: 'onRequest',

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,19 +1,26 @@
-import Fastify from 'fastify'
+import Fastify, {FastifyRequest} from 'fastify'
 import fastifyExpress from '..'
 import { expectType } from "tsd"
 import { Application } from 'express'
 
 const app = Fastify()
 
+app.decorateRequest('testTsd', '')
 app.register(fastifyExpress)
 app.register(fastifyExpress, {
-  expressHook: 'onRequest'
+  expressHook: 'onRequest',
+  createProxyHandler: (fastifyReq) => ({
+    set(target, prop, value) {
+      expectType<FastifyRequest>(fastifyReq)
+      return Reflect.set(target, prop, value)
+    }
+  })
 })
 
 expectType<Application>(app.express)
 
 app.express.disable('x-powered-by')
 
-app.use('/world', (_req, res) => {
+app.use('/world', (req, res) => {
   res.sendStatus(200)
 })

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,4 +1,4 @@
-import Fastify, {FastifyRequest} from 'fastify'
+import Fastify, { FastifyRequest } from 'fastify'
 import fastifyExpress from '..'
 import { expectType } from "tsd"
 import { Application } from 'express'
@@ -21,6 +21,6 @@ expectType<Application>(app.express)
 
 app.express.disable('x-powered-by')
 
-app.use('/world', (req, res) => {
+app.use('/world', (_req, res) => {
   res.sendStatus(200)
 })


### PR DESCRIPTION
Adds support for a [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) around the Express request object.

It's difficult to migrate to Fastify from a complex set of Express middleware used by many services that have assumptions about some data being on the request object or expect to set data to the request that is consumed by other middleware. 

Using Fastify server has resulted in some edge cases where it's not possible to easily migrate middleware A and not middleware B at the same time, moving both would be a huge effort and not very realistic todo at the same time. Adding a Proxy gives us the ability to let Express middleware read and write from Fastify decorators as a short term migration solution.

For example consider this snippet from the test file, it allows the Express middleware to read from both decorators and mutate the `getAndSetFastify` decorator which can then be used by Fastify plugins.

```js
  fastify.decorateRequest('getAndSetFastify', 'original message')
  fastify.decorateRequest('getOnlyFastify',  'original message')

  fastify.register(expressPlugin, {
    createProxyHandler: fastifyReq => ({
      set (target, prop, value) {
        if (prop === 'getAndSetFastify') {
          return Reflect.set(fastifyReq, prop, value)
        } else if (prop === 'getOnlyFastify') {
          return true
        } else {
          return Reflect.set(target, prop, value)
        }
      },
      get (target, prop) {
        if (prop === 'getAndSetFastify' || prop === 'getOnlyFastify') {
          // Return something from Fastify req
          return fastifyReq[prop]
        }

        return target[prop]
      }
    })
  })
    .after(() => {
      fastify.use(function (req, res, next) {
        req.getAndSetFastify = 'updated'
        // This will NOT updated Fastify req
        req.getOnlyFastify = 'updated'
        next()
      })
    })

  fastify.get('/', function (request, reply) {
    // getOnlyFastify should change and getOnlyFastify should not
    console.log(request.getAndSetFastify) // updated
    console.log(request.getOnlyFastify) // original message

    reply.send({ hello: 'world' })
  })
```

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark` - tests only, didn't see benchmarks script in package
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
