### PR TITLE
fix: express mutated request.url

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,13 +40,19 @@ function fastifyExpress (fastify, options, next) {
       req.raw = new Proxy(req.raw, createProxyHandler(req))
     }
 
-    req.raw.originalUrl = req.raw.url
+    const { url } = req.raw
+    req.raw.originalUrl = url
     req.raw.id = req.id
     req.raw.hostname = req.hostname
     req.raw.ip = req.ip
     req.raw.ips = req.ips
     req.raw.log = req.log
     reply.raw.log = req.log
+    reply.raw.send = function send (...args) {
+      // Restore req.raw.url to its original value https://github.com/fastify/fastify-express/issues/11
+      req.raw.url = url
+      return reply.send.apply(reply, args)
+    }
 
     // backward compatibility for body-parser
     if (req.body) {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -578,7 +578,7 @@ test('Middleware chain (with errors) / 2', t => {
 })
 
 test('Send a response from a middleware', t => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
 
@@ -602,8 +602,9 @@ test('Send a response from a middleware', t => {
     t.fail('We should not be here')
   })
 
-  fastify.addHook('onSend', (req, reply, next) => {
-    t.fail('We should not be here')
+  fastify.addHook('onSend', (req, reply, payload, next) => {
+    t.ok('called')
+    next(null, payload)
   })
 
   fastify.addHook('onResponse', (req, reply, next) => {

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -2,6 +2,7 @@
 
 const { test } = require('tap')
 const Fastify = require('fastify')
+const express = require('express')
 const expressPlugin = require('../index')
 
 test('onSend hook should receive valid request and reply objects if middleware fails', t => {
@@ -33,5 +34,39 @@ test('onSend hook should receive valid request and reply objects if middleware f
   }, (err, res) => {
     t.error(err)
     t.equal(res.statusCode, 500)
+  })
+})
+
+test('request.url is not mutated between onRequest and onResponse', t => {
+  t.plan(4)
+  const fastify = Fastify()
+  const targetUrl = '/hubba/bubba'
+
+  fastify.addHook('onRequest', (request, _, next) => {
+    t.equal(request.url, targetUrl)
+    next()
+  })
+
+  fastify.addHook('onResponse', (request, _, next) => {
+    t.equal(request.url, targetUrl)
+    next()
+  })
+
+  fastify.register(expressPlugin).after(() => {
+    const mainRouter = express.Router()
+    const innerRouter = express.Router()
+    mainRouter.use('/hubba', innerRouter)
+    innerRouter.get('/bubba', (req, res) => {
+      res.sendStatus(200)
+    })
+    fastify.use(mainRouter)
+  })
+
+  fastify.inject({
+    method: 'GET',
+    url: targetUrl
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.statusCode, 200)
   })
 })

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -253,7 +253,7 @@ test('middlewares with prefix', t => {
 })
 
 test('res.end should block middleware execution', t => {
-  t.plan(5)
+  t.plan(6)
 
   const instance = fastify()
   t.teardown(instance.close)
@@ -278,7 +278,8 @@ test('res.end should block middleware execution', t => {
   })
 
   instance.addHook('onSend', (req, reply, payload, next) => {
-    t.fail('this should not be called')
+    t.ok('called')
+    next(null, payload)
   })
 
   instance.addHook('onResponse', (request, reply, next) => {


### PR DESCRIPTION
Fixes #11

I tried @Eomm's [suggestion](https://github.com/fastify/fastify-express/issues/11#issuecomment-845096584), but in this case next is never called, so it does not resolve the issue.

However, this solution does cause onSend to be called where it was not before. Would you consider this a breaking change or is it alright?

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
