### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@types/node": "*",
     "body-parser": "^1.20.2",
     "cors": "^2.8.5",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "helmet": "^8.0.0",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.