### PR TITLE
fix: decode paths before matching

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const fp = require('fastify-plugin')
 const Express = require('express')
+const FindMyWay = require('find-my-way')
 const kMiddlewares = Symbol('fastify-express-middlewares')
 
 function fastifyExpress (fastify, options, next) {
@@ -80,6 +81,9 @@ function fastifyExpress (fastify, options, next) {
         reply.raw.setHeader(headerName, headerValue)
       }
 
+      // Decode URL before Express matches middleware to prevent encoded path bypass
+      // e.g., /%61dmin should match middleware registered on /admin
+      req.raw.url = FindMyWay.sanitizeUrlPath(req.raw.url)
       this.express(req.raw, reply.raw, next)
     } else {
       next()

--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ function fastifyExpress (fastify, options, next) {
     }
 
     const { url } = req.raw
+
+    const decodedUrl = FindMyWay.sanitizeUrlPath(url)
+    // Decode URL before Express matches middleware to prevent encoded path bypass
+    // e.g., /%61dmin should match middleware registered on /admin
+    req.raw.url = decodedUrl
     req.raw.originalUrl = url
     req.raw.id = req.id
     req.raw.hostname = req.hostname
@@ -51,7 +56,7 @@ function fastifyExpress (fastify, options, next) {
     reply.raw.log = req.log
     reply.raw.send = function send (...args) {
       // Restore req.raw.url to its original value https://github.com/fastify/fastify-express/issues/11
-      req.raw.url = url
+      req.raw.url = decodedUrl
       return reply.send.apply(reply, args)
     }
 
@@ -81,9 +86,6 @@ function fastifyExpress (fastify, options, next) {
         reply.raw.setHeader(headerName, headerValue)
       }
 
-      // Decode URL before Express matches middleware to prevent encoded path bypass
-      // e.g., /%61dmin should match middleware registered on /admin
-      req.raw.url = FindMyWay.sanitizeUrlPath(req.raw.url)
       this.express(req.raw, reply.raw, next)
     } else {
       next()

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
   },
   "dependencies": {
     "express": "^5.1.0",
-    "fastify-plugin": "^5.0.0"
+    "fastify-plugin": "^5.0.0",
+    "find-my-way": "^9.4.0"
   },
   "tsd": {
     "directory": "test/types"

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -6,6 +6,7 @@ const { test } = require('node:test')
 const fastify = require('fastify')
 const fp = require('fastify-plugin')
 const cors = require('cors')
+const express = require('express')
 const helmet = require('helmet')
 
 const expressPlugin = require('../index')
@@ -367,48 +368,92 @@ test('middlewares should run in the order in which they are defined', async t =>
 })
 
 test('middlewares for encoded paths', async t => {
-  t.plan(2)
-
-  const instance = fastify()
-  t.after(() => instance.close())
-  instance.register(expressPlugin)
-    .after(() => {
-      instance.use('/encoded', function (req, _res, next) {
-        req.slashed = true
-        next()
-      })
-      instance.use('/%65ncoded', function (req, _res, next) {
-        req.slashedSpecial = true
-        next()
-      })
-    })
-
-  function handler (request, reply) {
-    reply.send({
-      slashed: request.raw.slashed,
-      slashedSpecial: request.raw.slashedSpecial
-    })
-  }
-
-  instance.get('/encoded', handler)
-  instance.get('/%65ncoded', handler)
-
-  const address = await instance.listen({ port: 0 })
-
   await t.test('decode the request url and run the middleware', async (t) => {
-    t.plan(2)
-    const response = await fetch(address + '/%65ncod%65d') // '/encoded'
-    t.assert.ok(response.ok)
-    const body = await response.json()
-    t.assert.deepStrictEqual(body, { slashed: true })
+    await checkEncodedPath('/encoded', '/%65ncoded', t)
   })
 
   await t.test('does not double decode the url', async (t) => {
-    t.plan(2)
-    const response = await fetch(address + '/%2565ncoded')
-    const body = await response.json()
+    await checkEncodedPath('/%65ncoded', '/%2565ncoded', t)
+  })
 
+  await t.test('handle the decoding for express handlers', async (t) => {
+    t.plan(6)
+
+    const routeUrl = '/express'
+    const requestUrl = '/%65xpress'
+
+    const instance = fastify()
+    t.after(() => instance.close())
+
+    instance.addHook('onSend', async function hook (request, reply, payload) {
+      t.assert.deepStrictEqual(request.raw.url, routeUrl)
+      t.assert.deepStrictEqual(request.raw.originalUrl, requestUrl)
+      return payload
+    })
+
+    instance.addHook('onResponse', async function hook (request, reply) {
+      t.assert.deepStrictEqual(request.raw.url, routeUrl)
+      t.assert.deepStrictEqual(request.raw.originalUrl, requestUrl)
+    })
+
+    await instance.register(expressPlugin)
+
+    // Register the express-like middleware
+    instance.use(routeUrl, function (req, _res, next) {
+      req.slashedByExpress = true
+      next()
+    })
+
+    // Register an express Router with an express handler
+    const innerRouter = express.Router()
+    innerRouter.get(routeUrl, function (req, res) {
+      res.send({ slashedByExpress: req.slashedByExpress })
+    })
+    instance.use(innerRouter)
+
+    const address = await instance.listen({ port: 0 })
+
+    const response = await fetch(address + requestUrl)
+    const body = await response.json()
     t.assert.ok(response.ok)
-    t.assert.deepStrictEqual(body, { slashedSpecial: true })
+    t.assert.deepStrictEqual(body, { slashedByExpress: true })
   })
 })
+
+async function checkEncodedPath (routeUrl, requestUrl, t) {
+  t.plan(6)
+
+  const instance = fastify()
+  t.after(() => instance.close())
+
+  instance.addHook('onSend', async function hook (request, reply, payload) {
+    t.assert.deepStrictEqual(request.raw.url, routeUrl)
+    t.assert.deepStrictEqual(request.raw.originalUrl, requestUrl)
+    return payload
+  })
+
+  instance.addHook('onResponse', async function hook (request, reply) {
+    t.assert.deepStrictEqual(request.raw.url, routeUrl)
+    t.assert.deepStrictEqual(request.raw.originalUrl, requestUrl)
+  })
+
+  await instance.register(expressPlugin)
+
+  // Register the express-like middleware
+  instance.use(routeUrl, function (req, _res, next) {
+    req.slashed = true
+    next()
+  })
+
+  // ... with a Fastify route handler
+  instance.get(routeUrl, (request, reply) => {
+    reply.send({ slashed: request.raw.slashed, })
+  })
+
+  const address = await instance.listen({ port: 0 })
+
+  const response = await fetch(address + requestUrl)
+  const body = await response.json()
+  t.assert.ok(response.ok)
+  t.assert.deepStrictEqual(body, { slashed: true })
+}


### PR DESCRIPTION
URL-encoded paths could bypass middleware (e.g., /%61dmin would bypass middleware registered on /admin). This uses FindMyWay.sanitizeUrlPath() to decode URLs before Express matches middleware, consistent with the fix in fastify/middie#245.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test && npm run benchmark --if-present`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
