### PR TITLE
fix: decode url with query params

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@
 
 const fp = require('fastify-plugin')
 const Express = require('express')
-const FindMyWay = require('find-my-way')
 const kMiddlewares = Symbol('fastify-express-middlewares')
 
 function fastifyExpress (fastify, options, next) {
@@ -43,9 +42,7 @@ function fastifyExpress (fastify, options, next) {
 
     const { url } = req.raw
 
-    const decodedUrl = FindMyWay.sanitizeUrlPath(url)
-    // Decode URL before Express matches middleware to prevent encoded path bypass
-    // e.g., /%61dmin should match middleware registered on /admin
+    const decodedUrl = decodeURI(url)
     req.raw.url = decodedUrl
     req.raw.originalUrl = url
     req.raw.id = req.id

--- a/package.json
+++ b/package.json
@@ -76,8 +76,7 @@
   },
   "dependencies": {
     "express": "^4.18.3",
-    "fastify-plugin": "^5.0.0",
-    "find-my-way": "^9.4.0"
+    "fastify-plugin": "^5.0.0"
   },
   "tsd": {
     "directory": "test/types"

--- a/test/enhance-request.test.js
+++ b/test/enhance-request.test.js
@@ -56,6 +56,26 @@ test('trust proxy protocol', async (t) => {
   })
 })
 
+test('query params still in in the request url after decodeURI', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+
+  t.after(() => fastify.close())
+
+  fastify.register(expressPlugin).after(() => {
+    fastify.use('/admin', function (req, res) {
+      t.assert.deepStrictEqual(req.originalUrl, '/%61dmin?test=%76alue&test2=%76alue', 'originalUrl is not decoded')
+      t.assert.deepStrictEqual(req.url, '/admin?test=value&test2=value', 'url is decoded')
+
+      res.sendStatus(200)
+    })
+  })
+
+  const address = await fastify.listen({ port: 0 })
+
+  await fetch(`${address}/%61dmin?test=%76alue&test2=%76alue`)
+})
+
 test('passing createProxyHandler sets up a Proxy with Express req', async t => {
   t.plan(6)
   const testString = 'test proxy'


### PR DESCRIPTION
Change how the url is decoded.
Related to this issue: **https://github.com/fastify/fastify-express/issues/177**

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
