### PR TITLE
fix: set headerSent flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,14 +83,14 @@ function fastifyExpress (fastify, options, next) {
       req.raw.cookies = req.cookies
     }
 
-    // ** Request ** 
+    // ** Request **
     Object.defineProperty(req.raw, 'protocol', {
       get () {
         return req.protocol
       }
     })
 
-    // ** Response ** 
+    // ** Response **
     Object.defineProperty(reply.raw, 'headersSent', {
       get () { return replySent },
       configurable: true

--- a/index.js
+++ b/index.js
@@ -60,7 +60,14 @@ function fastifyExpress (fastify, options, next) {
     req.raw.ips = req.ips
     req.raw.log = req.log
     reply.raw.log = req.log
+
+    let replySent = false
     reply.raw.send = function send (...args) {
+      if (replySent) {
+        return
+      }
+
+      replySent = true
       // Restore req.raw.url to its original value https://github.com/fastify/fastify-express/issues/11
       req.raw.url = normalizedUrl
       return reply.send.apply(reply, args)
@@ -76,11 +83,17 @@ function fastifyExpress (fastify, options, next) {
       req.raw.cookies = req.cookies
     }
 
-    // Make it lazy as it does a bit of work
+    // ** Request ** 
     Object.defineProperty(req.raw, 'protocol', {
       get () {
         return req.protocol
       }
+    })
+
+    // ** Response ** 
+    Object.defineProperty(reply.raw, 'headersSent', {
+      get () { return replySent },
+      configurable: true
     })
 
     next()

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -25,7 +25,7 @@ test('express error middlewares chained via next(err) must not crash the process
   })
 
   // Second error middleware: should skip sending because headersSent is true.
-  app.use((err, _req, res, _next) => {
+  app.use((_err, _req, res, _next) => {
     if (!res.headersSent) {
       res.status(500).json({ error: 'fallback' })
     }
@@ -59,7 +59,7 @@ test('express error middleware that sends unconditionally must not crash the pro
   })
 
   // Second error middleware sends unconditionally — exercises the replySent guard.
-  app.use((err, _req, res, _next) => {
+  app.use((_err, _req, res, _next) => {
     res.status(500).json({ error: 'should be blocked by replySent guard' })
   })
 

--- a/test/hooks.test.js
+++ b/test/hooks.test.js
@@ -5,6 +5,72 @@ const Fastify = require('fastify')
 const express = require('express')
 const expressPlugin = require('../index')
 
+test('express error middlewares chained via next(err) must not crash the process when the first middleware already sent a response', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  await fastify.register(expressPlugin)
+
+  const app = express()
+
+  app.get('/foo', (_req, _res, next) => {
+    next(new Error('route error'))
+  })
+
+  // First error middleware: send a response, then pass the error along.
+  app.use((err, _req, res, next) => {
+    res.status(500).json({ error: err.message })
+    next(err)
+  })
+
+  // Second error middleware: should skip sending because headersSent is true.
+  app.use((err, _req, res, _next) => {
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'fallback' })
+    }
+  })
+
+  fastify.use(app)
+
+  const address = await fastify.listen({ port: 0 })
+  const result = await fetch(`${address}/foo`)
+  t.assert.deepStrictEqual(result.status, 500)
+  t.assert.deepStrictEqual(await result.json(), { error: 'route error' })
+})
+
+test('express error middleware that sends unconditionally must not crash the process after the first send', async t => {
+  t.plan(2)
+  const fastify = Fastify()
+  t.after(() => fastify.close())
+
+  await fastify.register(expressPlugin)
+
+  const app = express()
+
+  app.get('/bar', (_req, _res, next) => {
+    next(new Error('route error'))
+  })
+
+  // First error middleware sends and forwards the error.
+  app.use((err, _req, res, next) => {
+    res.status(500).json({ error: err.message })
+    next(err)
+  })
+
+  // Second error middleware sends unconditionally — exercises the replySent guard.
+  app.use((err, _req, res, _next) => {
+    res.status(500).json({ error: 'should be blocked by replySent guard' })
+  })
+
+  fastify.use(app)
+
+  const address = await fastify.listen({ port: 0 })
+  const result = await fetch(`${address}/bar`)
+  t.assert.deepStrictEqual(result.status, 500)
+  t.assert.deepStrictEqual(await result.json(), { error: 'route error' })
+})
+
 test('onSend hook should receive valid request and reply objects if middleware fails', async t => {
   t.plan(3)
   const fastify = Fastify()


### PR DESCRIPTION
This fix sets the https://nodejs.org/api/http.html#responseheaderssent value for express+fastify

Since Express error middleware chains execute synchronously, a second middleware runs before writableEnded becomes `true`. It sees `res.headersSent ===` false and calls `res.json()` again, triggering a second `reply.send()` → a second `onSend` chain → a second `safeWriteHead` → boom.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
